### PR TITLE
Implement drag state machine and automation context menu

### DIFF
--- a/apps/web/components/daw/context-menus/automation-context-menu.tsx
+++ b/apps/web/components/daw/context-menus/automation-context-menu.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useAtom } from "jotai";
+import { useState } from "react";
+import {
+	ContextMenu,
+	ContextMenuContent,
+	ContextMenuItem,
+	ContextMenuSeparator,
+	ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import type {
+	Track,
+	TrackEnvelopePoint,
+	TrackEnvelopeSegment,
+} from "@/lib/daw-sdk";
+import {
+	addAutomationPoint,
+	removeAutomationPoint,
+	updateSegmentCurve,
+	updateTrackAtom,
+} from "@/lib/daw-sdk";
+
+type AutomationContextMenuProps = {
+	track: Track;
+	trackHeight: number;
+	pxPerMs: number;
+	onAddPoint?: (point: TrackEnvelopePoint) => void;
+	children: React.ReactNode;
+};
+
+export function AutomationContextMenu({
+	track,
+	trackHeight,
+	pxPerMs,
+	onAddPoint,
+	children,
+}: AutomationContextMenuProps) {
+	const [, updateTrack] = useAtom(updateTrackAtom);
+	const [contextMenuState, setContextMenuState] = useState<{
+		x: number;
+		y: number;
+		clientX: number;
+		clientY: number;
+	} | null>(null);
+	const [copiedAutomation, setCopiedAutomation] = useState<{
+		points: TrackEnvelopePoint[];
+		segments: TrackEnvelopeSegment[];
+	} | null>(null);
+
+	const handleContextMenu = (e: React.MouseEvent<HTMLDivElement>) => {
+		const rect = e.currentTarget.getBoundingClientRect();
+		const x = e.clientX - rect.left;
+		const y = e.clientY - rect.top;
+		setContextMenuState({ x, y, clientX: e.clientX, clientY: e.clientY });
+	};
+
+	const handleAddPoint = () => {
+		if (!contextMenuState || !track.volumeEnvelope) return;
+
+		const time = contextMenuState.x / pxPerMs;
+		const padding = 20;
+		const usableHeight = trackHeight - padding * 2;
+		const normalizedY =
+			(trackHeight - padding - contextMenuState.y) / usableHeight;
+		const value = Math.max(0, Math.min(4, normalizedY * 4));
+
+		const newPoint: TrackEnvelopePoint = {
+			id: `point-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+			time,
+			value,
+		};
+
+		const updatedEnvelope = addAutomationPoint(track.volumeEnvelope, newPoint);
+
+		updateTrack(track.id, {
+			volumeEnvelope: updatedEnvelope,
+		});
+
+		onAddPoint?.(newPoint);
+	};
+
+	const handleDeletePoint = () => {
+		if (!contextMenuState || !track.volumeEnvelope) return;
+
+		// Find point near cursor
+		const time = contextMenuState.x / pxPerMs;
+		const nearestPoint = track.volumeEnvelope.points.reduce(
+			(nearest, point) => {
+				const dist = Math.abs(point.time - time);
+				return dist < nearest.dist ? { point, dist } : nearest;
+			},
+			{ point: null as TrackEnvelopePoint | null, dist: Infinity },
+		);
+
+		if (nearestPoint.point && nearestPoint.dist < 100) {
+			const updatedEnvelope = removeAutomationPoint(
+				track.volumeEnvelope,
+				nearestPoint.point.id,
+			);
+
+			updateTrack(track.id, {
+				volumeEnvelope: updatedEnvelope,
+			});
+		}
+	};
+
+	const handleResetSegmentCurve = () => {
+		if (!contextMenuState || !track.volumeEnvelope) return;
+
+		const time = contextMenuState.x / pxPerMs;
+		const sorted = [...track.volumeEnvelope.points].sort(
+			(a, b) => a.time - b.time,
+		);
+
+		// Find segment at cursor
+		for (let i = 0; i < sorted.length - 1; i++) {
+			const p1 = sorted[i];
+			const p2 = sorted[i + 1];
+
+			if (time >= p1.time && time <= p2.time) {
+				const segment = track.volumeEnvelope.segments?.find(
+					(s) => s.fromPointId === p1.id && s.toPointId === p2.id,
+				);
+
+				if (segment) {
+					const updatedEnvelope = updateSegmentCurve(
+						track.volumeEnvelope,
+						segment.id,
+						0,
+					);
+
+					updateTrack(track.id, {
+						volumeEnvelope: updatedEnvelope,
+					});
+				}
+				break;
+			}
+		}
+	};
+
+	const handleCopyAutomation = () => {
+		if (!track.volumeEnvelope) return;
+
+		setCopiedAutomation({
+			points: track.volumeEnvelope.points,
+			segments: track.volumeEnvelope.segments || [],
+		});
+	};
+
+	const handlePasteAutomation = () => {
+		if (!copiedAutomation || !contextMenuState) return;
+
+		const offset = contextMenuState.x / pxPerMs;
+		const minTime = Math.min(...copiedAutomation.points.map((p) => p.time));
+
+		// Shift all points by offset
+		const newPoints = copiedAutomation.points.map((p) => ({
+			...p,
+			id: crypto.randomUUID(),
+			time: p.time - minTime + offset,
+		}));
+
+		updateTrack(track.id, {
+			volumeEnvelope: {
+				enabled: true,
+				points: [...(track.volumeEnvelope?.points || []), ...newPoints],
+				segments: [...(track.volumeEnvelope?.segments || [])],
+			},
+		});
+	};
+
+	return (
+		<ContextMenu>
+			<ContextMenuTrigger asChild>
+				{/* biome-ignore lint/a11y/noStaticElementInteractions: Context menu trigger wrapper */}
+				<div onContextMenu={handleContextMenu}>{children}</div>
+			</ContextMenuTrigger>
+			<ContextMenuContent className="w-56" alignOffset={-4}>
+				<ContextMenuItem onClick={handleAddPoint}>
+					Add Point at Cursor
+				</ContextMenuItem>
+				<ContextMenuItem onClick={handleDeletePoint}>
+					Delete Nearest Point
+				</ContextMenuItem>
+				<ContextMenuSeparator />
+				<ContextMenuItem onClick={handleResetSegmentCurve}>
+					Reset Segment Curve
+				</ContextMenuItem>
+				<ContextMenuSeparator />
+				<ContextMenuItem onClick={handleCopyAutomation}>
+					Copy Automation
+				</ContextMenuItem>
+				<ContextMenuItem
+					onClick={handlePasteAutomation}
+					disabled={!copiedAutomation}
+				>
+					Paste Automation
+				</ContextMenuItem>
+			</ContextMenuContent>
+		</ContextMenu>
+	);
+}

--- a/apps/web/components/daw/controls/global-shortcuts.tsx
+++ b/apps/web/components/daw/controls/global-shortcuts.tsx
@@ -4,9 +4,9 @@ import { useAtom } from "jotai";
 import { useEffect } from "react";
 import {
 	automationViewEnabledAtom,
-	clearTracksAtom,
 	playbackAtom,
 	projectEndOverrideAtom,
+	resetProjectAtom,
 	selectedClipIdAtom,
 	selectedTrackIdAtom,
 	setCurrentTimeAtom,
@@ -33,7 +33,7 @@ export function GlobalShortcuts() {
 	const [automationViewEnabled, setAutomationViewEnabled] = useAtom(
 		automationViewEnabledAtom,
 	);
-	const [, clearTracks] = useAtom(clearTracksAtom);
+	const [, resetProject] = useAtom(resetProjectAtom);
 
 	useEffect(() => {
 		const ensureSelection = () => {
@@ -276,15 +276,15 @@ export function GlobalShortcuts() {
 				return;
 			}
 
-			// Cmd/Ctrl+Shift+Backspace: Clear all tracks
-			if (
-				(e.metaKey || e.ctrlKey) &&
-				e.shiftKey &&
-				e.key === "Backspace"
-			) {
+			// Cmd/Ctrl+Shift+Backspace: Reset project
+			if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "Backspace") {
 				e.preventDefault();
-				if (confirm("Clear all tracks and start fresh?")) {
-					clearTracks();
+				if (
+					confirm(
+						"Reset project to default state? This will clear all tracks and settings.",
+					)
+				) {
+					resetProject();
 				}
 				return;
 			}
@@ -308,7 +308,7 @@ export function GlobalShortcuts() {
 		setSelectedTrackId,
 		automationViewEnabled,
 		setAutomationViewEnabled,
-		clearTracks,
+		resetProject,
 	]);
 
 	return null;

--- a/apps/web/components/daw/panels/automation-lane.tsx
+++ b/apps/web/components/daw/panels/automation-lane.tsx
@@ -312,6 +312,7 @@ export function AutomationLane({
 			trackHeight={trackHeight}
 			pxPerMs={pxPerMs}
 		>
+			{/* biome-ignore lint/a11y/useKeyWithClickEvents: Click requires mouse coordinates; keyboard access via context menu */}
 			<svg
 				ref={svgRef}
 				className="pointer-events-auto absolute inset-0"
@@ -320,11 +321,6 @@ export function AutomationLane({
 				style={{ zIndex: 10 }}
 				aria-label={`Volume automation for ${track.name}`}
 				onClick={handleSvgClick}
-				onKeyDown={(e) => {
-					if (e.key === "Enter" || e.key === " ") {
-						handleSvgClick(e as unknown as React.MouseEvent<SVGSVGElement>);
-					}
-				}}
 			>
 				<title>{`Volume automation: ${sorted.length} points (Cmd/Ctrl+Click or double-click to add)`}</title>
 

--- a/apps/web/lib/daw-sdk/state/machines/drag-machine.ts
+++ b/apps/web/lib/daw-sdk/state/machines/drag-machine.ts
@@ -1,0 +1,104 @@
+import { assign, setup } from "xstate";
+
+type DragContext = {
+	clipId: string | null;
+	originTrackId: string | null;
+	originStartTime: number;
+	previewTrackId: string | null;
+	previewStartTime: number;
+	cursorOffsetX: number;
+	cursorOffsetY: number;
+};
+
+type DragEvent =
+	| {
+			type: "START_CLIP_DRAG";
+			clipId: string;
+			trackId: string;
+			startTime: number;
+			offsetX: number;
+			offsetY: number;
+	  }
+	| {
+			type: "MOVE";
+			previewTrackId: string;
+			previewStartTime: number;
+	  }
+	| { type: "DROP" }
+	| { type: "CANCEL" };
+
+export const dragMachine = setup({
+	types: {
+		context: {} as DragContext,
+		events: {} as DragEvent,
+	},
+}).createMachine({
+	id: "drag",
+	initial: "idle",
+	context: {
+		clipId: null,
+		originTrackId: null,
+		originStartTime: 0,
+		previewTrackId: null,
+		previewStartTime: 0,
+		cursorOffsetX: 0,
+		cursorOffsetY: 0,
+	},
+	states: {
+		idle: {
+			on: {
+				START_CLIP_DRAG: {
+					target: "dragging",
+					actions: assign({
+						clipId: ({ event }) => event.clipId,
+						originTrackId: ({ event }) => event.trackId,
+						originStartTime: ({ event }) => event.startTime,
+						previewTrackId: ({ event }) => event.trackId,
+						previewStartTime: ({ event }) => event.startTime,
+						cursorOffsetX: ({ event }) => event.offsetX,
+						cursorOffsetY: ({ event }) => event.offsetY,
+					}),
+				},
+			},
+		},
+		dragging: {
+			on: {
+				MOVE: {
+					actions: assign({
+						previewTrackId: ({ event }) => event.previewTrackId,
+						previewStartTime: ({ event }) => event.previewStartTime,
+					}),
+				},
+				DROP: {
+					target: "dropping",
+				},
+				CANCEL: {
+					target: "idle",
+					actions: assign({
+						clipId: null,
+						originTrackId: null,
+						originStartTime: 0,
+						previewTrackId: null,
+						previewStartTime: 0,
+						cursorOffsetX: 0,
+						cursorOffsetY: 0,
+					}),
+				},
+			},
+		},
+		dropping: {
+			always: {
+				target: "idle",
+				actions: assign({
+					clipId: null,
+					originTrackId: null,
+					originStartTime: 0,
+					previewTrackId: null,
+					previewStartTime: 0,
+					cursorOffsetX: 0,
+					cursorOffsetY: 0,
+				}),
+			},
+		},
+	},
+});

--- a/apps/web/lib/daw-sdk/utils/automation-utils.ts
+++ b/apps/web/lib/daw-sdk/utils/automation-utils.ts
@@ -480,6 +480,36 @@ export function addAutomationPoint(
 }
 
 /**
+ * Shift automation points in a time range by a delta (for same-track clip moves)
+ */
+export function shiftAutomationInRange(
+	track: Track,
+	startTime: number,
+	endTime: number,
+	deltaMs: number,
+): Track {
+	const envelope = track.volumeEnvelope;
+	if (!envelope || !envelope.enabled || !envelope.points) {
+		return track;
+	}
+
+	const shiftedPoints = envelope.points.map((point) => {
+		if (point.time >= startTime && point.time <= endTime) {
+			return { ...point, time: Math.max(0, point.time + deltaMs) };
+		}
+		return point;
+	});
+
+	return {
+		...track,
+		volumeEnvelope: {
+			...envelope,
+			points: shiftedPoints,
+		},
+	};
+}
+
+/**
  * Remove automation point and clean up segments
  */
 export function removeAutomationPoint(


### PR DESCRIPTION
## Description

This PR introduces a comprehensive overhaul of the clip dragging functionality, unifies project reset, and adds a new context menu for automation lanes.

The core objective is to provide a predictable and atomic drag experience for clips, where changes are only committed on drop, and a clear preview is shown during the drag. This addresses previous issues like clips disappearing during same-track drags. Additionally, a unified project reset mechanism is implemented, and a new context menu enhances automation editing with options to add/delete points, reset segment curves, and copy/paste automation.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI changes
- [x] ♻️ Code refactoring
- [ ] ⚡ Performance improvements
- [ ] 🧪 Tests
- [ ] 🔧 Build/CI changes

## Component

- [ ] WAV0 AI Agent
- [x] Studio/DAW
- [ ] Playground
- [ ] Vault
- [ ] Audio Engine
- [x] UI/UX
- [ ] API
- [ ] Documentation
- [ ] Other:

## Testing

- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in different browsers (if applicable)

## Screenshots/Recordings

<!-- If applicable, add screenshots or screen recordings to help explain your changes -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" -->

Fixes #

## Additional Notes

-   Leverages XState and Jotai-XState for robust and predictable drag state management.
-   The previous `AutomationTransferDialog` has been removed in favor of a streamlined drag experience with undo coalescing for clip moves.
-   Automation point addition now supports `Cmd/Ctrl+Click` in addition to double-click.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe748c29-efdf-4113-be03-8c40f5f10909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fe748c29-efdf-4113-be03-8c40f5f10909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds XState-powered clip dragging with preview/commit-on-drop, a context menu for automation (add/delete/reset/copy-paste), and a unified project reset with updated shortcut.
> 
> - **DAW UI**:
>   - **Clip Dragging (XState)**: Introduces `drag-machine` with Jotai-XState integration; drag preview derived from machine, events `START_CLIP_DRAG`/`MOVE`/`DROP` wired in `daw-track-content`.
>   - **Drag Behavior**: Commit changes on drop; same-track moves shift automation in-range; cross-track moves transfer points+segments; live preview overlay.
>   - **Automation Lane**:
>     - Wraps with `AutomationContextMenu` enabling add/delete point, reset segment curve, copy/paste.
>     - Supports Cmd/Ctrl+Click (and double-click) to add points.
> - **State/Utils**:
>   - Adds `shiftAutomationInRange` to adjust automation during same-track moves.
>   - Adds `resetProjectAtom`; normalizes `clearTracksAtom` and envelope updates.
>   - Replaces ad-hoc drag preview atom with machine-driven `dragMachineAtom` and derived `dragPreviewAtom`.
> - **Shortcuts**:
>   - Updates Cmd/Ctrl+Shift+Backspace to use `resetProjectAtom` with clearer confirmation text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe6feb5012d765ce6417a3335669394853f42851. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->